### PR TITLE
Reset listView.currentIndex

### DIFF
--- a/UI/main.qml
+++ b/UI/main.qml
@@ -109,6 +109,7 @@ ApplicationWindow {
                            onClicked: {
                               loader.source = "qrc:/pages/search.qml"
                                stackView.push(loader.item)
+                               listView.currentIndex = -1
                            }
 
 
@@ -159,7 +160,6 @@ ApplicationWindow {
 
            initialItem: Pane {
                id: pane
-               anchors.fill: parent
 
 
 


### PR DESCRIPTION
Reset listView.currentIndex to -1 to allow Manage page reloading

Delete anchors fill to prevent anchors collision error
